### PR TITLE
Fix || GitHub Publish Action Not Triggering

### DIFF
--- a/.github/workflows/android_publish.yml
+++ b/.github/workflows/android_publish.yml
@@ -3,7 +3,7 @@ name: Android Publish
 on:
   push:
     branches:
-      -'release/**'
+      - 'release/**'
 
 jobs:
   build:


### PR DESCRIPTION
Fixes #12 

Action was not triggered because of missing space in definition of branches to trigger action