### PR TITLE
Feature: Remove App Bar

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="false"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme.NoActionBar">
         <activity android:name=".activity.MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/tomerpacific/laundry/Utilities.kt
+++ b/app/src/main/java/com/tomerpacific/laundry/Utilities.kt
@@ -1,27 +1,17 @@
 package com.tomerpacific.laundry
 
-import android.app.Activity
-import android.content.res.AssetManager
 import android.graphics.Typeface
 import android.widget.ImageButton
 import android.widget.TextView
 import androidx.appcompat.widget.TooltipCompat
-import java.util.*
 
 class Utilities {
 
     companion object {
 
-        fun setFont(activity: Activity, fontToSet: String, viewIdToSetFont: Int) {
-
-            activity.findViewById<TextView>(viewIdToSetFont).apply {
-                val assetManager: AssetManager = activity.assets
-                val typeFace: Typeface = Typeface.createFromAsset(
-                    assetManager,
-                    String.format(Locale.US, "fonts/%s", fontToSet)
-                )
-                this?.typeface = typeFace
-            }
+        fun setFont(view: TextView, fontToSet: String) {
+            val typeface = Typeface.createFromAsset(view.context.assets,"fonts/${fontToSet}");
+            view.typeface = typeface
         }
 
         fun setTooltipForSymbol(imageButton: ImageButton) {

--- a/app/src/main/java/com/tomerpacific/laundry/fragment/LaundryCategoriesFragment.kt
+++ b/app/src/main/java/com/tomerpacific/laundry/fragment/LaundryCategoriesFragment.kt
@@ -50,11 +50,12 @@ class LaundryCategoriesFragment: Fragment() {
     }
 
     private fun setFontAndVersion() {
-        Utilities.setFont(
-            requireActivity(),
-            BANGERS_FONT,
-            R.id.textView
-        )
+        activity?.let {
+            Utilities.setFont(
+                it.findViewById(R.id.textView),
+                BANGERS_FONT,
+            )
+        }
 
         requireActivity().findViewById<TextView>(R.id.app_version).apply {
             this?.text = getString(

--- a/app/src/main/java/com/tomerpacific/laundry/fragment/LaundryCategoryFragment.kt
+++ b/app/src/main/java/com/tomerpacific/laundry/fragment/LaundryCategoryFragment.kt
@@ -37,9 +37,8 @@ class LaundryCategoryFragment : Fragment() {
         laundryCategoryTextView.text = laundryCategory
 
         Utilities.setFont(
-            requireActivity(),
-            BANGERS_FONT,
-            R.id.laundry_category_textview
+            view.findViewById(R.id.laundry_category_textview),
+            BANGERS_FONT
         )
 
         val gridLayout: GridView = view.findViewById(R.id.grid_layout)

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -8,4 +8,8 @@
         <item name="colorAccent">@color/colorAccent</item>
     </style>
 
+    <style name="AppTheme.NoActionBar" parent="AppTheme">
+        <item name="windowNoTitle">true</item>
+    </style>
+
 </resources>


### PR DESCRIPTION
Fixes #16 

To free up some real estate for the application, it was needed to remove the application bar.
Following the addition of the noActionBar style, it was observed that the font is not being set correctly for laundry category fragment.
This was due to the fact that the view was not being found.

To correct this behavior, the setFont method in the Utility class was refactored.