### PR TITLE
Fix: GitHub Publish Action

### DIFF
--- a/.github/workflows/android_publish.yml
+++ b/.github/workflows/android_publish.yml
@@ -46,3 +46,4 @@ jobs:
           packageName: com.tomerpacific.laundry
           releaseFiles: app/build/outputs/bundle/release/app-release.aab
           track: production
+          status: inProgress


### PR DESCRIPTION
Fixes #25 

Looking at the error, it appears the API has changed and requires to pass in the **status** field.

