### PR TITLE
Feature: Upgrading checkout version in build/publish actions

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -8,7 +8,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set Up JDK
         uses: actions/setup-java@v1

--- a/.github/workflows/android_publish.yml
+++ b/.github/workflows/android_publish.yml
@@ -11,7 +11,9 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set Up JDK
         uses: actions/setup-java@v1


### PR DESCRIPTION
Resolves #90 
This pull request updates the GitHub Actions workflows for Android build and publish processes to use a newer version of the `actions/checkout` action and ensure the correct pull request commit is checked out.
