### PR TITLE
LaundrySymbols supporting 16 KB Page Size

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ espresso-core = "3.4.0"
 ui-test-junit4 = "1.1.0"
 ui-test-manifest = "1.6.2"
 
-androidGradlePlugin = "8.5.0"
+androidGradlePlugin = "8.9.1"
 kotlin = "2.0.0"
 
 [libraries]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sat Jul 16 08:10:38 IDT 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Resolves #101 

Per the documentation, all that was needed to do was upgrade the AGP version to be at least 8.5.1.
Also, when inspecting the APK with APK Analyzer, the only present .so file showed no alignment issues.