### PR TITLE
Android 17 Support

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,11 +7,11 @@ plugins {
 
 android {
     namespace = "com.tomerpacific.laundry"
-    compileSdk = 36
+    compileSdk = 37
     defaultConfig {
         applicationId = "com.tomerpacific.laundry"
         minSdk = 21
-        targetSdk = 36
+        targetSdk = 37
         versionCode = 34
         versionName = "2.7.1"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,7 +14,7 @@ espresso-core = "3.4.0"
 ui-test-junit4 = "1.1.0"
 ui-test-manifest = "1.6.2"
 
-androidGradlePlugin = "8.9.1"
+androidGradlePlugin = "8.13.2"
 kotlin = "2.0.0"
 
 [libraries]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sat Jul 16 08:10:38 IDT 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Resolves #164 

This pull request updates the project to use the latest Android and Gradle toolchain versions, ensuring compatibility with the newest features and improvements. The main changes involve bumping the compile and target SDK versions, updating the Android Gradle plugin version, and upgrading the Gradle wrapper.

**Toolchain and SDK Upgrades:**

* Increased `compileSdk` and `targetSdk` versions to 37 in `app/build.gradle.kts` for compatibility with the latest Android APIs.
* Updated the `androidGradlePlugin` version to 8.13.2 in `gradle/libs.versions.toml` to match the latest Android Gradle Plugin release.
* Upgraded the Gradle wrapper to version 8.13 in `gradle/wrapper/gradle-wrapper.properties` for improved build performance and compatibility.